### PR TITLE
Replacing SHA-1 with CityHash64

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -4,10 +4,11 @@
 package cuckoofilter
 
 import (
-	"crypto/sha1"
 	"encoding/binary"
 	"errors"
 	"math/rand"
+
+	"github.com/zhenjl/cityhash"
 )
 
 // 4 entries per bucket is suggested by the paper in section 5.1,
@@ -64,8 +65,7 @@ func New(maxKeys uint32) *Filter {
 }
 
 func hash(data []byte) uint64 {
-	s := sha1.Sum(data)
-	return binary.LittleEndian.Uint64(s[:])
+	return cityhash.CityHash64(data, uint32(len(data)))
 }
 
 func (f *Filter) bucketIndex(hv uint32) uint32 {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/joeshaw/cuckoofilter
 
 go 1.12
+
+require github.com/zhenjl/cityhash v0.0.0-20131128155616-cdd6a94144ab


### PR DESCRIPTION
Hi Joe,

the crux of my commit is replacing SHA-1 with CityHash64. The resulting speedup is ~3x, at a little expense of a false positive rate. What do you think about it?

SHA-1:
<pre>False positive rate (before deletes): 7 / 100000
False positive rate (after deletes): 2 / 100000
PASS
ok  	github.com/joeshaw/cuckoofilter	0.238s

BenchmarkAdd-4        	 2489659	       501 ns/op
BenchmarkContains-4   	 2472956	       491 ns/op
BenchmarkDelete-4     	 2521711	       491 ns/op
</pre>

CityHash:
<pre>False positive rate (before deletes): 13 / 100000
False positive rate (after deletes): 3 / 100000
PASS
ok  	github.com/joeshaw/cuckoofilter	0.047s

BenchmarkAdd-4        	11847450	       150 ns/op
BenchmarkContains-4   	14749201	       152 ns/op
BenchmarkDelete-4     	14251442	       178 ns/op
</pre>

Even though the false positive rate climbed up 2x, it is still <0.01%, which is fairly acceptable, considering the speed boost.

The need of a faster version of Cuckoo filter has occurred to me just recently when I was building an event processing engine. I'd rather process a couple of events once again if it lowers the overall processing time, the filter gets cleared every n hours anyway. Might be applicable elsewhere.

Perhaps, if you find the requirement of a false positive rate more substantial than the speed-up benefit, we can create a new branch with CityHash version.

Please, let me know what your thoughts are on it.